### PR TITLE
Fix broken imports

### DIFF
--- a/networkgrave.py
+++ b/networkgrave.py
@@ -1,8 +1,8 @@
 import os
 #local imports
-from src/ng import wificardtools as wificard
-from src/ng import features as f
-from src/ng import menus
+from src.ng import wificardtools as wificard
+from src.ng import features as f
+from src.ng import menus
 
 #colors
 red = "\033[31m"

--- a/nodejammer.py
+++ b/nodejammer.py
@@ -1,8 +1,8 @@
 import os
 from threading import Thread
 #local imports
-from src/nj import wificardtools as wificard
-from src/nj import features as f
+from src.nj import wificardtools as wificard
+from src.nj import features as f
 
 #colors
 red = "\033[31m"

--- a/src/ng/features.py
+++ b/src/ng/features.py
@@ -1,7 +1,7 @@
 import subprocess
 from scapy.all import *
 from threading import Thread
-import wificardtools as wificard
+from . import wificardtools as wificard
 
 #colors
 red = "\033[31m"

--- a/src/ng/wificardtools.py
+++ b/src/ng/wificardtools.py
@@ -1,4 +1,3 @@
-Learn more or give us feedback
 import subprocess
 import time
 

--- a/src/nj/features.py
+++ b/src/nj/features.py
@@ -3,7 +3,7 @@ import time
 
 from scapy.all import *
 from threading import Thread
-from srcnj import wificardtools as wificard
+from . import wificardtools as wificard
 
 #ap array
 AP_BSSID = []


### PR DESCRIPTION
## Summary
- fix import paths in main scripts
- use relative imports inside package modules
- remove stray text from wifi card tools

## Testing
- `python3 -m py_compile networkgrave.py nodejammer.py src/ng/*.py src/nj/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687af0d63ed0832eb30044086856157b